### PR TITLE
fixes short tag for those of us who have them disabled

### DIFF
--- a/Classes/Command/Imdb.php
+++ b/Classes/Command/Imdb.php
@@ -1,4 +1,4 @@
-<?
+<?php
 // Namespace
 namespace Command;
 


### PR DESCRIPTION
They are generally discouraged.

"PHP also allows for short open tags <? and ?> (which are discouraged because they are only available if enabled with short_open_tag php.ini configuration file directive, or if PHP was configured with the --enable-short-tags option. "

http://www.php.net/manual/en/language.basic-syntax.phptags.php

Wanted to merge this in as I like this project and am hoping to add some cool features to the foundation you have ^.^ 
