### PR TITLE
fixed empty timezone error and use America/New_York as sample timezone

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,6 +7,7 @@ return array(
     'channels' => array(
         '#phpbot404',
     ),
+    'timezone' => 'America/New_York',
     'max_reconnects' => 1,
     'log_file'       => 'log.txt',
     'commands'       => array(

--- a/phpbot404.php
+++ b/phpbot404.php
@@ -29,6 +29,13 @@
         $config = include_once(ROOT_DIR . '/config.php');
     }
 
+    if (empty(ini_get('date.timezone'))) {
+        if (empty($config['timezone']))
+            $config['timezone'] = 'UTC';
+
+        date_default_timezone_set($config['timezone']);
+    }
+
     spl_autoload_register( 'Autoloader::load' );
 
     // Create the bot.

--- a/phpbot404.php
+++ b/phpbot404.php
@@ -29,7 +29,8 @@
         $config = include_once(ROOT_DIR . '/config.php');
     }
 
-    if (empty(ini_get('date.timezone'))) {
+    $timezone = ini_get('date.timezone');
+    if (empty($timezone)) {
         if (empty($config['timezone']))
             $config['timezone'] = 'UTC';
 


### PR DESCRIPTION
hi, i think its' a problem when user didn't set default timezone.
I patch a timezone code, and make sample timezone as 'America/New_York' in config.php 
(I think it's author's time zone, ha) 

if there's no timezone setting in config.php, it will use UTC as default.