### PR TITLE
Now allow an array to be set for $numberOfArguments

### DIFF
--- a/Classes/Command/Quit.php
+++ b/Classes/Command/Quit.php
@@ -16,6 +16,13 @@ class Quit extends \Library\IRC\Command\Base {
     * @var string
     */
     protected $help = '!quit';
+    
+    /**
+     * The number of arguments the command needs.
+     *
+     * @var integer
+     */
+    protected $numberOfArguments = 0;
 
     /**
      * Leave IRC altogether. This disconnects from the server.

--- a/Classes/Command/Restart.php
+++ b/Classes/Command/Restart.php
@@ -16,6 +16,13 @@ class Restart extends \Library\IRC\Command\Base {
     * @var string
     */
     protected $help = '!restart';
+    
+    /**
+     * The number of arguments the command needs.
+     *
+     * @var integer
+     */
+    protected $numberOfArguments = 0;
 
     /**
      * Restarts the bot.

--- a/Classes/Library/IRC/Command/Base.php
+++ b/Classes/Library/IRC/Command/Base.php
@@ -93,19 +93,40 @@
             // Set data
             $this->data = $data;
 
-            // If a number of arguments is incorrect then run the command, if
-            // not then show the relevant help text.
-            if ($this->numberOfArguments != -1 && count( $arguments ) != $this->numberOfArguments) {
-                // Show help text.
-                $this->say(' Incorrect Arguments. Usage: ' . $this->getHelp());
+            // If it's an int...
+            if (is_numeric($this->numberOfArguments))
+            {
+                if (($this->numberOfArguments === -1 && count($arguments) == 0) || ($this->numberOfArguments !== -1 && count($arguments) != $this->numberOfArguments))
+                {
+                    $this->say('Error: illegal amount of arguments. For help, use !help ' . str_replace('Command\\', '', get_class($this)));
+                    return;
+                }
             }
-            else {
-                // Set Arguments
-                $this->arguments = $arguments;
+            
+            // But if it's an array... An array means this command can take multiple counts of arguments, and react accordingly.
+            elseif (is_array($this->numberOfArguments))
+            {
+                if (!((in_array(count($arguments), $this->numberOfArguments)) || (in_array(-1, $this->numberOfArguments) && count($arguments) >= 1)))
+                {
+                    $this->say('Error: illegal amount of arguments. For help, use !help ' . str_replace('Command\\', '', get_class($this)));
+                    return;
+                }
+            }
+            
+            // Some safeguarding here.
+            else
+            {
+                $this->bot->log(get_class($this) . ': No number of arguments variable set. Please add the $numberOfArguments variable to your command file.');
+                $this->bot->log('This command will not work until fixed.');
+                return;
+            }
+            
+            // Set Arguments
+            $this->arguments = $arguments;
 
-                // Execute the command.
-                $this->command();
-            }
+            // Execute the command.
+            $this->command();
+            
         }
 
         /**


### PR DESCRIPTION
[ETA: Sorry, my title got cut off by my shell; it interpreted $numberOfArguments as a variable]
On the built-in commands this isn't applicable. But consider this:
My bot has an !issue command. If !issue is passed without parameters, it will return the last 5 issues posted on GitHub. If !issue has 1 parameter, it will return info  about a specific issue.

Now, before this patch, $numberOfArguments was required to be set to -1. This allows multiple arguments to be passed, while it will only process one.

With this patch, I can simply set it to array(0, 1) and it'll take either 0 or 1 argument(s), and errors out on anything else. -1 can still be passed in the array and it behaves differently after this patch.
Before: -1 would include 0 arguments as correct. After: -1 will now work if amount of arguments > 0
This is done to avoid possible issues that could arise from passing no arguments to a command that won't work without arguments. To allow both 0 and any amount of arguments, pass array(0, -1).

This patch also includes a safeguard that will block commands that do not have the $numberOfArguments set from running, again to prevent issues which can arise by an incorrect amount of arguments.

Do note that I left the "For help, use !help [command name]" in here. If you want to remove it, go ahead.
Signed-off-by: Yoshi2889 <rick.2889@gmail.com>