### PR TITLE
Improve Quit and Restart commands; fix #43

### DIFF
--- a/Classes/Command/Quit.php
+++ b/Classes/Command/Quit.php
@@ -29,13 +29,20 @@ class Quit extends \Library\IRC\Command\Base {
      *
      * @var integer
      */
-    protected $numberOfArguments = 0;
+    protected $numberOfArguments = array(0, -1);
 
     /**
      * Leave IRC altogether. This disconnects from the server.
      */
     public function command() {
-        $this->connection->sendData('QUIT');
+        if (count($this->arguments) == 0) {
+            $message = 'Quit: WildPHP <http://wildphp.com/>';
+        }
+        else {
+            $message = trim(preg_replace('/\s\s+/', ' ',  implode(' ', $this->arguments)));
+        }
+
+        $this->connection->sendData('QUIT :' . $message);
         exit;
     }
 }

--- a/Classes/Command/Restart.php
+++ b/Classes/Command/Restart.php
@@ -29,18 +29,25 @@ class Restart extends \Library\IRC\Command\Base {
      *
      * @var integer
      */
-    protected $numberOfArguments = 0;
+    protected $numberOfArguments = array(0, -1);
 
     /**
      * Restarts the bot.
      */
     public function command() {
+        if (count($this->arguments) == 0) {
+            $message = 'Restarting...';
+        }
+        else {
+            $message = trim(preg_replace('/\s\s+/', ' ',  implode(' ', $this->arguments)));
+        }
+        
         // Exit from Sever
-        $this->connection->sendData('QUIT :Restarting...');
-		
-		// Wait 5 Seconds Before Rejoin
-		sleep(5);
-		
+        $this->connection->sendData('QUIT :' . $message);
+
+        // Wait 5 Seconds Before Rejoin
+        sleep(5);
+
         // Reconnect to Server
         $this->bot->connectToServer();
     }


### PR DESCRIPTION
Both now take a message for quitting. If you want to test this (at least on Freenode), your bot needs to be online for a while or these messages won't work.

Excuse the quite ugly code, at least it's better than a one-liner I suppose.
Signed-off-by: Yoshi2889 <rick.2889@gmail.com>